### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/azuredevops400/762be424-0ea5-47bf-8039-bfe4a07c5915/4236d18b-ced4-42e8-9343-36cbe69627c8/_apis/work/boardbadge/574ff992-ecce-4c44-86ce-d1335f07179b)](https://dev.azure.com/azuredevops400/762be424-0ea5-47bf-8039-bfe4a07c5915/_boards/board/t/4236d18b-ced4-42e8-9343-36cbe69627c8/Microsoft.RequirementCategory)
 - 👋 Hi, I’m Ajay Khanna
 - 👀 I’m interested in Azure, modern cloud development and Devops
 - 🌱 I’m currently learning K8S and Devops


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#569](https://dev.azure.com/azuredevops400/762be424-0ea5-47bf-8039-bfe4a07c5915/_workitems/edit/569). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.